### PR TITLE
Add "Dankest Dungeon" memes

### DIFF
--- a/dankest-dungeon.js
+++ b/dankest-dungeon.js
@@ -7,13 +7,19 @@ const rl = readline.createInterface({
 	output: process.stdout
 });
 
-const darkestDungeonFeedUrl = 'https://www.reddit.com/r/darkestdungeon/hot.json?limit=100';
+const darkestDungeonFeedUrl = 'https://www.reddit.com/r/darkestdungeon/hot.json?limit=150';
 var darkestDungeonMemes = [];
 const maxMemes = 20;
+var memeCounter = 0;
+var afterSlug = '';
 
-const dankestDungeonMemes = () => {
+const dankestDungeonMemes = (after = null) => {
+	var fetchUrl = darkestDungeonFeedUrl;
+	if ( after ) {
+		fetchUrl += '&after=' + after;
+	}
 	console.log('Descending into dankness...');
-	fetch(darkestDungeonFeedUrl, {
+	fetch(fetchUrl, {
 		method: "GET"
 	})
 	.then(res => { return res.json(); })
@@ -24,22 +30,29 @@ const dankestDungeonMemes = () => {
 				darkestDungeonMemes.push(res.data.children[i].data);
 			}
 		}
+		afterSlug = res.data.after;
 	})
 	.then(() => {
 		console.log('Today\'s dankest dungeon memes:');
-		for(var i=0; i<darkestDungeonMemes.length; i++) {
+		for(i = memeCounter; i<darkestDungeonMemes.length; i++) {
 			console.log((i+1) + '. ' + darkestDungeonMemes[i].title);
 		}
-		rl.question('Choose a meme! (1-' + i + '):', (selection) => {
-			if ( isNaN(selection) || ! darkestDungeonMemes[selection-1] ) {
+		console.log('Deeper!')
+		rl.question('Choose a meme! (' + (memeCounter+1) + '-' + i + ') or delve "deeper":', (selection) => {
+			if ( selection.toLowerCase().includes('deeper') ) {
+				memeCounter = i;
+				dankestDungeonMemes(afterSlug);
+			} else if ( isNaN(selection) || ! darkestDungeonMemes[selection-1] ) {
 				console.log('Send this one to journey elsewhere, for we have need of sterner stock.');
 				rl.close();
 				process.exit();
 				return;
+			} else {
+				opn(darkestDungeonMemes[selection-1].url);
+				rl.close();
+				process.exit();
 			}
-			opn(darkestDungeonMemes[selection-1].url);
-			rl.close();
-			process.exit();
+			
 		});
 	});
 };

--- a/dankest-dungeon.js
+++ b/dankest-dungeon.js
@@ -43,7 +43,7 @@ const dankestDungeonMemes = (after = null) => {
 			console.log((i+1) + '. ' + darkestDungeonMemes[i].title);
 		}
 		console.log('Deeper!')
-		rl.question('Choose a meme! (1-' + i + ') or delve "deeper":', (selection) => {
+		rl.question('Choose a meme! (1-' + i + ') or delve "deeper": ', (selection) => {
 			if ( selection.toLowerCase().includes('deeper') ) {
 				memeCounter = i;
 				dankestDungeonMemes(afterSlug);

--- a/dankest-dungeon.js
+++ b/dankest-dungeon.js
@@ -1,0 +1,47 @@
+const readline = require('readline');
+const fetch = require('node-fetch');
+const opn = require('opn');
+
+const rl = readline.createInterface({
+	input: process.stdin,
+	output: process.stdout
+});
+
+const darkestDungeonFeedUrl = 'https://www.reddit.com/r/darkestdungeon/hot.json?limit=100';
+var darkestDungeonMemes = [];
+const maxMemes = 20;
+
+const dankestDungeonMemes = () => {
+	console.log('Descending into dankness...');
+	fetch(darkestDungeonFeedUrl, {
+		method: "GET"
+	})
+	.then(res => { return res.json(); })
+	.then(res => {
+		// Collect only the memes.
+		for(var i=0; i<res.data.children.length && darkestDungeonMemes.length<=maxMemes; i++) {
+			if ('meme' === res.data.children[i].data.link_flair_css_class) {
+				darkestDungeonMemes.push(res.data.children[i].data);
+			}
+		}
+	})
+	.then(() => {
+		console.log('Today\'s dankest dungeon memes:');
+		for(var i=0; i<darkestDungeonMemes.length; i++) {
+			console.log((i+1) + '. ' + darkestDungeonMemes[i].title);
+		}
+		rl.question('Choose a meme! (1-' + i + '):', (selection) => {
+			if ( isNaN(selection) || ! darkestDungeonMemes[selection-1] ) {
+				console.log('Send this one to journey elsewhere, for we have need of sterner stock.');
+				rl.close();
+				process.exit();
+				return;
+			}
+			opn(darkestDungeonMemes[selection-1].url);
+			rl.close();
+			process.exit();
+		});
+	});
+};
+
+dankestDungeonMemes();

--- a/dankest-dungeon.js
+++ b/dankest-dungeon.js
@@ -15,10 +15,13 @@ var afterSlug = '';
 
 const dankestDungeonMemes = (after = null) => {
 	var fetchUrl = darkestDungeonFeedUrl;
+	var message = 'Descending into dankness...';
 	if ( after ) {
 		fetchUrl += '&after=' + after;
+		message = 'Descending deeper into dankness...';
 	}
-	console.log('Descending into dankness...');
+	console.log('');
+	console.log(message);
 	fetch(fetchUrl, {
 		method: "GET"
 	})
@@ -33,12 +36,14 @@ const dankestDungeonMemes = (after = null) => {
 		afterSlug = res.data.after;
 	})
 	.then(() => {
-		console.log('Today\'s dankest dungeon memes:');
+		if ( ! after ) {
+			console.log('Today\'s dankest dungeon memes:');
+		}
 		for(i = memeCounter; i<darkestDungeonMemes.length; i++) {
 			console.log((i+1) + '. ' + darkestDungeonMemes[i].title);
 		}
 		console.log('Deeper!')
-		rl.question('Choose a meme! (' + (memeCounter+1) + '-' + i + ') or delve "deeper":', (selection) => {
+		rl.question('Choose a meme! (1-' + i + ') or delve "deeper":', (selection) => {
 			if ( selection.toLowerCase().includes('deeper') ) {
 				memeCounter = i;
 				dankestDungeonMemes(afterSlug);


### PR DESCRIPTION
# Description
This adds command to delve into the depths that of memes based on the dungeon crawling game "Darkest Dungeon", whose meme-community I lovingly refer to as Dankest Dungeon.

Includes the ability to delve deeper and deeper. How deep do you dare venture?

## Steps to Test
1. Pull down this branch and run `node dankest-dungeon.js`
2. Choose one of the selections and it should load in browser
3. Say "deeper" to load more offerings (note, can still select previous item)
4. Type something invalid to get the boot.


## Screenshots
![image](https://user-images.githubusercontent.com/1346732/46831949-6d5f7500-cd6a-11e8-9c29-275365b66588.png)



## Deploy Notes
<!--- Provide any deployment notes / instructions (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have tested these code changes and included the relevant urls and screenshots.
- [ ] I have updated our build tasks accordingly (if applicable).
- [ ] I have updated our documentation accordingly (if applicable).
- [ ] I have linted the code that I've included in this PR (if applicable).
- [x] My code follows the code style of this project.
- [x] My code is ready for review.
