### PR TITLE
Remove max memes as it broke deep delving

### DIFF
--- a/dankest-dungeon.js
+++ b/dankest-dungeon.js
@@ -9,7 +9,6 @@ const rl = readline.createInterface({
 
 const darkestDungeonFeedUrl = 'https://www.reddit.com/r/darkestdungeon/hot.json?limit=150';
 var darkestDungeonMemes = [];
-const maxMemes = 20;
 var memeCounter = 0;
 var afterSlug = '';
 
@@ -28,7 +27,7 @@ const dankestDungeonMemes = (after = null) => {
 	.then(res => { return res.json(); })
 	.then(res => {
 		// Collect only the memes.
-		for(var i=0; i<res.data.children.length && darkestDungeonMemes.length<=maxMemes; i++) {
+		for(var i=0; i<res.data.children.length; i++) {
 			if ('meme' === res.data.children[i].data.link_flair_css_class) {
 				darkestDungeonMemes.push(res.data.children[i].data);
 			}


### PR DESCRIPTION
# Description
Fix to be able to delve deeper into the Dank Dungeon! Allows to go beyond level 20 🥇 


## Steps to Test
<!--- Please describe in detail how you tested your changes. -->


## Screenshots
![image](https://user-images.githubusercontent.com/1346732/46839659-9d1b7680-cd84-11e8-85db-0c6baf255dff.png)



## Deploy Notes
<!--- Provide any deployment notes / instructions (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have tested these code changes and included the relevant urls and screenshots.
- [ ] I have updated our build tasks accordingly (if applicable).
- [ ] I have updated our documentation accordingly (if applicable).
- [ ] I have linted the code that I've included in this PR (if applicable).
- [x] My code follows the code style of this project.
- [x] My code is ready for review.
