### PR TITLE
Exit process without waiting for browser to close

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,10 @@ const generateRandomMeme = () => {
 		.then(r => {
 			return (r.data.memes[Math.floor(Math.random() * Math.floor(r.data.memes.length - 1))].url);
 		})
-		.then(url => opn(url))
-		.then(() => process.exit())
+		.then(url => {
+			opn(url);
+			process.exit();
+		})
 		.catch(console.error);
 }
 

--- a/make-meme.js
+++ b/make-meme.js
@@ -57,8 +57,10 @@ const generateMeme = (meme, caption1, caption2) => {
 	.then(r => {
 		return r.data.url;
 	})
-	.then(url => opn(url))
-	.then(() => process.exit())
+	.then(url => {
+		opn(url);
+		process.exit();
+	})
 	.catch(console.error);
 };
 

--- a/ron-swanson.js
+++ b/ron-swanson.js
@@ -42,8 +42,10 @@ const generateMeme = (meme_id, caption1) => {
 	.then(r => {
 		return r.data.url;
 	})
-	.then(url => opn(url))
-	.then(() => process.exit())
+	.then(url => {
+		opn(url);
+		process.exit();
+	})
 	.catch(console.error);
 };
 

--- a/roulette.js
+++ b/roulette.js
@@ -44,8 +44,10 @@ const generateRandomlyCaptionedMeme = (caption1, caption2) => {
 				.then(r => {
 					return r.data.url;
 				})
-				.then(url => opn(url))
-				.then(() => process.exit())
+				.then(url => {
+					opn(url);
+					process.exit();
+				})
 				.catch(console.error);
 		});
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->

# Description
The `index.js`, `make-meme.js`, `ron-swanson.js`, and `roulette.js` scripts were returning a promise from `opn`, which will not resolve until the browser is exited completely. In order to preserve our precious precious tabs and free up our super sweet terminals, the process is now exited right after the meme is generated. 👋 

This matches the behavior in `dankest-dungeon.js`, `reddit.js`, and `yo-dawg.js`. 👌 


## Steps to Test
1. Run `node index.js`.
2. Proceed through prompt (answering yes, selecting options, etc.)
3. View meme.
4. Confirm that CLI process has exited even if browser is still open.
5. Repeat 1 through 4 with `make-meme.js`, `ron-swanson.js`, and `roulette.js`.


## Screenshots
N/A


## Deploy Notes
N/A


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have tested these code changes and included the relevant urls and screenshots.
- [ ] I have updated our build tasks accordingly (if applicable).
- [ ] I have updated our documentation accordingly (if applicable).
- [ ] I have linted the code that I've included in this PR (if applicable).
- [x] My code follows the code style of this project.
- [x] My code is ready for review.
